### PR TITLE
Added support for escape

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,4 @@
-Flask==1.1.2
+Flask==2.1.0
 py-cpuinfo==7.0.0
 psutil==5.8.0
 gunicorn==20.1.0


### PR DESCRIPTION
Fixes dependencies issue while importing jinja2. For reference :-> [here](https://stackoverflow.com/questions/71718167/importerror-cannot-import-name-escape-from-jinja2)